### PR TITLE
DOCSP-40004 added comma guidance and removed percent encoding guidance

### DIFF
--- a/source/includes/authentication/auth-properties-commas.rst
+++ b/source/includes/authentication/auth-properties-commas.rst
@@ -1,5 +1,5 @@
 .. note::
     
-    If your ``authMechanismProperty`` values include a comma, you must use the ``MongoClient`` constructor to set your authentication options.
+    If your ``authMechanismProperties`` values include a comma, you must use the ``MongoClient`` constructor to set your authentication options.
     
     

--- a/source/includes/authentication/auth-properties-commas.rst
+++ b/source/includes/authentication/auth-properties-commas.rst
@@ -1,0 +1,5 @@
+.. note::
+    
+    If your ``authMechanismProperty`` values include a comma, you must use the ``MongoClient`` constructor to set your authentication options.
+    
+    

--- a/source/security/authentication.txt
+++ b/source/security/authentication.txt
@@ -257,7 +257,8 @@ environment variables:
 - ``AWS_SESSION_TOKEN``
 
 To use these environment variables to authenticate your application, first set them to the
-AWS IAM values needed for authentication, as shown in the following code example:
+AWS IAM values needed for authentication, as shown in the following code
+example:
 
 .. code-block:: sh
 
@@ -411,11 +412,13 @@ After you create the config file, set the following connection options:
 - ``password``: The AWS IAM secret access key returned by the ``AssumeRole`` request.
   Percent-encode this value before including it in a connection URI..
 - ``authMechanismProperties``: Set to ``AWS_SESSION_TOKEN:`` and the
-  AWS session token returned by the ``AssumeRole`` request. Percent-encode this value before including it in a connection URI.
+  AWS session token returned by the ``AssumeRole`` request. 
 - ``authMechanism``: Set to ``"MONGODB-AWS"``.
 
 You can set these options in two ways: by passing arguments to the
 ``MongoClient`` constructor or through parameters in your connection string.
+
+.. include:: /includes/authentication/auth-properties-commas.rst
 
 .. tabs::
 

--- a/source/security/enterprise-authentication.txt
+++ b/source/security/enterprise-authentication.txt
@@ -71,7 +71,10 @@ to use Kerberos to authenticate.
         this option to ``"SERVICE_NAME:<authentication service name>"``.
 
       You can set these options in two ways: by passing arguments to the
-      ``MongoClient`` constructor or through parameters in your connection string.
+      ``MongoClient`` constructor or through parameters in your connection
+      string.
+      
+      .. include:: /includes/authentication/auth-properties-commas.rst
 
       .. tabs::
 
@@ -170,6 +173,8 @@ To authenticate with SASL, set the ``authMechanism`` connection option to ``PLAI
 You can set this option in two ways: by passing an argument to the
 ``MongoClient`` constructor or through a parameter in your connection string.
 
+.. include:: /includes/authentication/auth-properties-commas.rst
+   
 .. tabs::
 
    .. tab:: MongoClient
@@ -228,6 +233,8 @@ support.
 You can configure OIDC for Azure IMDS in two ways: by passing arguments to the
 ``MongoClient`` constructor or through parameters in your connection string.
 
+.. include:: /includes/authentication/auth-properties-commas.rst
+
 .. tabs::
 
    .. tab:: MongoClient
@@ -272,8 +279,8 @@ You can configure OIDC for Azure IMDS in two ways: by passing arguments to the
         enterprise application, set this to the application ID of the service principal. 
       - ``authMechanism``: Set to ``MONGODB-OIDC``.
       - ``authMechanismProperties``: Set to
-        ``ENVIRONMENT:azure,TOKEN_RESOURCE:<percent-encoded audience>``.
-        Replace the ``<percent-encoded audience>`` placeholder with the percent-encoded
+        ``ENVIRONMENT:azure,TOKEN_RESOURCE:<audience>``.
+        Replace the ``<audience>`` placeholder with the
         value of the ``audience`` parameter configured on your MongoDB deployment. 
         
         The following code example shows how to set these options in your connection string:
@@ -301,6 +308,8 @@ support.
 You can configure OIDC for GCP IMDS in two ways: by passing arguments to the
 ``MongoClient`` constructor or through parameters in your connection string.
 
+.. include:: /includes/authentication/auth-properties-commas.rst
+   
 .. tabs::
 
    .. tab:: MongoClient
@@ -337,8 +346,8 @@ You can configure OIDC for GCP IMDS in two ways: by passing arguments to the
 
       - ``authMechanism``: Set to ``MONGODB-OIDC``.
       - ``authMechanismProperties``: Set to
-        ``ENVIRONMENT:gcp,TOKEN_RESOURCE:<percent-encoded audience>``.
-        Replace the ``<percent-encoded audience>`` placeholder with the percent-encoded
+        ``ENVIRONMENT:gcp,TOKEN_RESOURCE:<audience>``.
+        Replace the ``<audience>`` placeholder with the
         value of the ``audience`` parameter configured on your MongoDB deployment.
 
       The following code example shows how to set these options in your connection string:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-40004>
Staging - <https://preview-mongodbshuangela.gatsbyjs.io/pymongo/DOCSP-40004-add-comma-directive-auth-properties/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
