### PR TITLE
DOCSP-40758 Fix typo in function name

### DIFF
--- a/source/write/insert.txt
+++ b/source/write/insert.txt
@@ -134,7 +134,7 @@ not customize the insert.
          fields </reference/command/insert/#command-fields>` guide in the
          {+mdb-server+} manual for more information.
 
-The ``InsertMany()`` method accepts the preceding optional parameters,
+The ``insert_many()`` method accepts the preceding optional parameters,
 as well as the optional ``ordered`` property:
 
 .. list-table::


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-40748
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/pymongo/DOCSP-40748-method-typo/write/insert/#modify-insert-behavior

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
