### PR TITLE
DOCSP-40986: Bump minimum pymongocrypt version req to >=1.10 for range v2 and async support

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,6 +104,14 @@ and upgrade versions.
 
 .. diagram for this example?
 
+.. _version-4.9-breaking-changes:
+
+Version 4.9 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``pymongocrypt`` v1.10 or later is required for 
+   :manual:`Client-Side Field Level Encryption </core/csfle>` (CSFLE).
+
 .. _version-4.8-breaking-changes:
 
 Version 4.8 Breaking Changes

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -47,6 +47,11 @@ The {+driver-short+} v4.10 release includes the following new features:
 What's New in 4.9
 -----------------
 
+.. warning:: Breaking Changes
+
+  {+driver-short+} v4.9 contains breaking changes. For more information, see
+  :ref:`version-4.9-breaking-changes`.
+
 The {+driver-short+} v4.9 release includes the following new features:
 
 - Adds support for {+mdb-server+} 8.0 and Python 3.13.
@@ -56,6 +61,7 @@ The {+driver-short+} v4.9 release includes the following new features:
   Encryption </core/queryable-encryption>` in the {+mdb-server+} manual.
 - Adds a new experimental asynchronous API as a replacement for Motor. This API
   is in beta and is subject to change before the generally available release.
+
 .. TODO: Add link to the Pymongo Async migration guide
 
 .. _version-4.8:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-40986>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
