### PR TITLE
DOCSP-43384: Troubleshooting openssl legacy unsafe renegotiation

### DIFF
--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -140,6 +140,7 @@ enforce legacy `TLS renegotiation <https://www.ibm.com/docs/en/i/7.3?topic=setti
 To resolve this issue, perform the following steps:
 
 .. procedure::
+   :style: normal
    
    .. step:: Check OpenSSL Version
 
@@ -150,7 +151,7 @@ To resolve this issue, perform the following steps:
 
          openssl version
 
-   .. step:: Use ``UnsafeLegacyServerConnect`` Option
+   .. step:: Use the ``UnsafeLegacyServerConnect`` Option
    
       Create a configuration file that includes the 
       ``UnsafeLegacyServerConnect`` option. The following example shows how to set 
@@ -170,7 +171,7 @@ To resolve this issue, perform the following steps:
          [system_default_sect]
          Options = UnsafeLegacyServerConnect
 
-   .. step:: Run Python With OpenSSL Configuration
+   .. step:: Run Python with OpenSSL Configuration
 
       Run Python while setting the ``OPENSSL_CONF`` environment variable to use
       the OpenSSL configuration file you just created:

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -134,14 +134,16 @@ message:
 
    MongoServerSelectionError: 886E0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:c:\ws\deps\openssl\openssl\ssl\statem\extensions.c:922:
 
-These types of errors occur due to outdated or buggy SSL proxies that mistakenly
+These types of errors occur because of outdated or buggy SSL proxies that mistakenly
 enforce legacy `TLS renegotiation <https://www.ibm.com/docs/en/i/7.3?topic=settings-renegotiation>`__. 
 
-To resolve this issue, use the ``UnsafeLegacyServerConnect`` option with the 
-``OPENSSL_CONF`` environment variable. Create a configuration
-file with the following content:
+To resolve this issue, create a configuration file that includes the 
+``UnsafeLegacyServerConnect`` option. This option requires OpenSSL v3.0.4 or 
+greater. The following example shows how to set the ``UnsafeLegacyServerConnect`` 
+option:
 
 .. code-block:: shell
+   :emphasize-lines: 10
 
    openssl_conf = openssl_init
 
@@ -154,16 +156,16 @@ file with the following content:
    [system_default_sect]
    Options = UnsafeLegacyServerConnect
 
-Then run Python using that OpenSSL config file:
+Then run Python while setting the ``OPENSSL_CONF`` environment variable to use
+OpenSSL configuration file you just created:
 
 .. code-block:: shell
 
    OPENSSL_CONF=/path/to/the/config/file/above.cnf python ...
 
-The ``UnsafeLegacyServerConnect`` option in ``OPENSSL_CONF`` requires OpenSSL v3.0.4 
-or greater.
+.. important::
 
-.. warning::
-
-   This workaround should only be used as a last resort to address ``unsafe legacy 
-   renegotiation disabled`` errors.
+   Because setting the ``UnsafeLegacyServerConnect`` option has 
+   `security implications <https://docs.openssl.org/3.0/man3/SSL_CTX_set_options/#patched-openssl-client-and-unpatched-server>`__, 
+   this workaround should only be used as a last 
+   resort to address ``unsafe legacy renegotiation disabled`` errors.

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -135,7 +135,7 @@ message:
    MongoServerSelectionError: 886E0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:c:\ws\deps\openssl\openssl\ssl\statem\extensions.c:922:
 
 These types of errors occur due to outdated or buggy SSL proxies that mistakenly
-enforce legacy TLS renegotiation. 
+enforce legacy `TLS renegotiation <https://www.ibm.com/docs/en/i/7.3?topic=settings-renegotiation>`__. 
 
 To resolve this issue, use the ``UnsafeLegacyServerConnect`` option with the 
 ``OPENSSL_CONF`` environment variable. Create a configuration

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -132,7 +132,7 @@ message:
 
 .. code-block:: python
 
-   MongoServerSelectionError: 886E0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:c:\ws\deps\openssl\openssl\ssl\statem\extensions.c:922:
+   [SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled
 
 These types of errors occur because of outdated or buggy SSL proxies that mistakenly
 enforce legacy `TLS renegotiation <https://www.ibm.com/docs/en/i/7.3?topic=settings-renegotiation>`__. 

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -132,13 +132,13 @@ message:
 
 .. code-block:: python
 
-   886E0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:c:\ws\deps\openssl\openssl\ssl\statem\extensions.c:922:
+   MongoServerSelectionError: 886E0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:c:\ws\deps\openssl\openssl\ssl\statem\extensions.c:922:
 
 These types of errors occur due to outdated or buggy SSL proxies that mistakenly
 enforce legacy TLS renegotiation. 
 
 To resolve this issue, use the ``UnsafeLegacyServerConnect`` option with the 
-``OPENSSL_CONF`` environment variable. To do this, create a configuration
+``OPENSSL_CONF`` environment variable. Create a configuration
 file with the following content:
 
 .. code-block:: shell

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -157,7 +157,7 @@ option:
    Options = UnsafeLegacyServerConnect
 
 Then run Python while setting the ``OPENSSL_CONF`` environment variable to use
-OpenSSL configuration file you just created:
+the OpenSSL configuration file you just created:
 
 .. code-block:: shell
 

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -123,3 +123,47 @@ following steps:
 - Downgrade Python to v3.9 or earlier
 - Upgrade {+mdb-server+} to v4.2 or later
 - Install {+driver-short+} with the :ref:`OCSP <pymongo-disable-ocsp>` option, which relies on PyOpenSSL
+
+Unsafe Legacy Renegotiation Disabled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using OpenSSL v3 or later, you might see an error similar to the following
+message:
+
+.. code-block:: python
+
+   886E0000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:c:\ws\deps\openssl\openssl\ssl\statem\extensions.c:922:
+
+These types of errors occur due to outdated or buggy SSL proxies that mistakenly
+enforce legacy TLS renegotiation. 
+
+To resolve this issue, use the ``UnsafeLegacyServerConnect`` option with the 
+``OPENSSL_CONF`` environment variable. To do this, create a configuration
+file with the following content:
+
+.. code-block:: shell
+
+   openssl_conf = openssl_init
+
+   [openssl_init]
+   ssl_conf = ssl_sect
+
+   [ssl_sect]
+   system_default = system_default_sect
+
+   [system_default_sect]
+   Options = UnsafeLegacyServerConnect
+
+Then run Python using that OpenSSL config file:
+
+.. code-block:: shell
+
+   OPENSSL_CONF=/path/to/the/config/file/above.cnf python ...
+
+The ``UnsafeLegacyServerConnect`` option in ``OPENSSL_CONF`` requires OpenSSL v3.0.4 
+or greater.
+
+.. warning::
+
+   This workaround should only be used as a last resort to address ``unsafe legacy 
+   renegotiation disabled`` errors.

--- a/source/includes/troubleshooting/tls.rst
+++ b/source/includes/troubleshooting/tls.rst
@@ -137,35 +137,51 @@ message:
 These types of errors occur because of outdated or buggy SSL proxies that mistakenly
 enforce legacy `TLS renegotiation <https://www.ibm.com/docs/en/i/7.3?topic=settings-renegotiation>`__. 
 
-To resolve this issue, create a configuration file that includes the 
-``UnsafeLegacyServerConnect`` option. This option requires OpenSSL v3.0.4 or 
-greater. The following example shows how to set the ``UnsafeLegacyServerConnect`` 
-option:
+To resolve this issue, perform the following steps:
 
-.. code-block:: shell
-   :emphasize-lines: 10
+.. procedure::
+   
+   .. step:: Check OpenSSL Version
 
-   openssl_conf = openssl_init
+      Run the following command to ensure that you have OpenSSL vv3.0.4 or
+      later installed:
 
-   [openssl_init]
-   ssl_conf = ssl_sect
+      .. code-block:: bash
 
-   [ssl_sect]
-   system_default = system_default_sect
+         openssl version
 
-   [system_default_sect]
-   Options = UnsafeLegacyServerConnect
+   .. step:: Use ``UnsafeLegacyServerConnect`` Option
+   
+      Create a configuration file that includes the 
+      ``UnsafeLegacyServerConnect`` option. The following example shows how to set 
+      the ``UnsafeLegacyServerConnect`` option:
 
-Then run Python while setting the ``OPENSSL_CONF`` environment variable to use
-the OpenSSL configuration file you just created:
+      .. code-block:: shell
+         :emphasize-lines: 10
 
-.. code-block:: shell
+         openssl_conf = openssl_init
 
-   OPENSSL_CONF=/path/to/the/config/file/above.cnf python ...
+         [openssl_init]
+         ssl_conf = ssl_sect
+
+         [ssl_sect]
+         system_default = system_default_sect
+
+         [system_default_sect]
+         Options = UnsafeLegacyServerConnect
+
+   .. step:: Run Python With OpenSSL Configuration
+
+      Run Python while setting the ``OPENSSL_CONF`` environment variable to use
+      the OpenSSL configuration file you just created:
+
+      .. code-block:: shell
+
+         OPENSSL_CONF=/path/to/the/config/file/above.cnf python ...
 
 .. important::
 
    Because setting the ``UnsafeLegacyServerConnect`` option has 
    `security implications <https://docs.openssl.org/3.0/man3/SSL_CTX_set_options/#patched-openssl-client-and-unpatched-server>`__, 
-   this workaround should only be used as a last 
+   use this workaround as a last 
    resort to address ``unsafe legacy renegotiation disabled`` errors.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-43384>
Staging - <https://deploy-preview-115--docs-pymongo.netlify.app/troubleshooting/#unsafe-legacy-renegotiation-disabled>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
