### PR TITLE
Undo DOCSP-45737

### DIFF
--- a/source/write/bulk-write.txt
+++ b/source/write/bulk-write.txt
@@ -67,11 +67,6 @@ The following example creates an instance of ``InsertOne``:
 
 To insert multiple documents, create an instance of ``InsertOne`` for each document.
 
-.. note::
-
-   You must specify a value for the ``_id`` field for each document you insert. If you don't,
-   the driver throws a ``DuplicateKeyError``.
-
 Update Operations
 ~~~~~~~~~~~~~~~~~
 

--- a/source/write/bulk-write.txt
+++ b/source/write/bulk-write.txt
@@ -67,6 +67,12 @@ The following example creates an instance of ``InsertOne``:
 
 To insert multiple documents, create an instance of ``InsertOne`` for each document.
 
+.. note::
+
+   Duplicate ``_id`` values violate unique index constraints, which causes the
+   driver to return a ``DuplicateKeyError``. To avoid this error, ensure that
+   each document you insert has a unique ``_id`` value.
+
 Update Operations
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
From Steve: "The _id doesn't have to be included in general, it is used for illustrative purposes in some of the examples.  The only constraint is that the _ids are unique.  If they're not provided by the client, they will be provided by the server."

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-45737>
Staging - <https://deploy-preview-134--docs-pymongo.netlify.app/write/bulk-write/>

