### PR TITLE
[PyMongo] Remove "MongoDB" from page title

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/source/index.txt
+++ b/source/index.txt
@@ -67,8 +67,8 @@ Write Data to MongoDB
 
 Learn how you can write data to MongoDB in the :ref:`pymongo-write` section.
 
-Read Data from MongoDB
-----------------------
+Read Data
+---------
 
 Learn how you can retrieve data from MongoDB in the :ref:`pymongo-read` section.
 

--- a/source/read.txt
+++ b/source/read.txt
@@ -1,8 +1,8 @@
 .. _pymongo-read:
 
-======================
-Read Data from MongoDB
-======================
+=========
+Read Data
+=========
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-48025>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-198--docs-pymongo.netlify.app/index>index</a></li><li><a href=https://deploy-preview-198--docs-pymongo.netlify.app/read>read</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
