### PR TITLE
DOCSP-46879: Add reference + link to MongoClient keyword arguments

### DIFF
--- a/source/connect/mongoclient.txt
+++ b/source/connect/mongoclient.txt
@@ -168,6 +168,11 @@ constructor accepts. All parameters are optional.
 
        **Data type:** `TypeRegistry <{+api-root+}bson/codec_options.html#bson.codec_options.TypeRegistry>`__
 
+You can also pass keyword arguments to the ``MongoClient()`` constructor to specify
+optional parameters. For a complete list of keyword arguments, see the
+`MongoClient <{+api-root+}pymongo/mongo_client.html#pymongo.mongo_client.MongoClient>`__ 
+class in the API documentation.
+
 Concurrent Execution
 --------------------
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -26,8 +26,6 @@ MongoDB {+driver-short+} Documentation
    Monitoring </monitoring>
    Serialization </serialization>
    Third-Party Tools </tools>
-   FAQ </faq>
-   Troubleshooting </troubleshooting>
    What's New </whats-new>
    Upgrade </upgrade>
    Migrate from Motor </motor-async-migration>

--- a/source/index.txt
+++ b/source/index.txt
@@ -123,12 +123,6 @@ Third-Party Tools
 For a list of popular third-party Python libraries for working with
 MongoDB, see the :ref:`pymongo-tools` section.
 
-Troubleshooting
----------------
-
-For solutions to issues you might encounter when using the driver, see the
-:ref:`pymongo-troubleshooting` section.
-
 What's New
 ----------
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-46879>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-199--docs-pymongo.netlify.app/connect/mongoclient>connect/mongoclient</a></li><li><a href=https://deploy-preview-199--docs-pymongo.netlify.app/index>index</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
