### PR TITLE
DOCSP-48166: Add async examples for Data Formats pages

### DIFF
--- a/source/data-formats/bson.txt
+++ b/source/data-formats/bson.txt
@@ -99,7 +99,9 @@ To read BSON documents from a file, open a file stream in read-binary mode on th
 file. Then, decode the documents from BSON format as you read them by using the ``bson.decode()``
 method.
 
-The following example reads the sample BSON document from ``file.bson``:
+The following example reads the sample BSON document from ``file.bson``. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding
+code.
 
 .. io-code-block::
    :copyable: true
@@ -107,10 +109,10 @@ The following example reads the sample BSON document from ``file.bson``:
    .. input::
       :language: python
 
-         with open("file.bson", "rb") as file:
-             data = file.read()
-             document = bson.decode(data)
-             print(document)
+      with open("file.bson", "rb") as file:
+          data = file.read()
+          document = bson.decode(data)
+          print(document)
 
    .. output::
       :visible: false
@@ -140,23 +142,49 @@ constructor to ``RawBSONDocument``.
 The following example configures a ``MongoClient`` object to use ``RawBSONDocument`` objects
 to model the collection, then retrieves the sample document from the preceding examples:
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
-      
-      from bson.raw_bson import RawBSONDocument
+      .. io-code-block::
+         :copyable: true
 
-      client = pymongo.MongoClient("<connection URI>", document_class=RawBSONDocument)
-      collection = client.sample_restaurants.restaurants
-      raw_doc = collection.find_one({"name": "Mongo's Pizza"})
-      print(type(raw_doc))
+         .. input::
+            :language: python
+            
+            from bson.raw_bson import RawBSONDocument
 
-   .. output::
-      :visible: false
+            client = pymongo.MongoClient("<connection URI>", document_class=RawBSONDocument)
+            collection = client.sample_restaurants.restaurants
+            raw_doc = collection.find_one({"name": "Mongo's Pizza"})
+            print(type(raw_doc))
 
-      <class 'bson.raw_bson.RawBSONDocument'>
+         .. output::
+            :visible: false
+
+            <class 'bson.raw_bson.RawBSONDocument'>
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+            
+            from bson.raw_bson import RawBSONDocument
+
+            client = pymongo.AsyncMongoClient("<connection URI>", document_class=RawBSONDocument)
+            collection = client.sample_restaurants.restaurants
+            raw_doc = await collection.find_one({"name": "Mongo's Pizza"})
+            print(type(raw_doc))
+
+         .. output::
+            :visible: false
+
+            <class 'bson.raw_bson.RawBSONDocument'>
 
 API Documentation
 -----------------

--- a/source/data-formats/bson.txt
+++ b/source/data-formats/bson.txt
@@ -99,9 +99,7 @@ To read BSON documents from a file, open a file stream in read-binary mode on th
 file. Then, decode the documents from BSON format as you read them by using the ``bson.decode()``
 method.
 
-The following example reads the sample BSON document from ``file.bson``. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding
-code.
+The following example reads the sample BSON document from ``file.bson``:
 
 .. io-code-block::
    :copyable: true
@@ -140,7 +138,9 @@ constructor to ``RawBSONDocument``.
    first convert it to a {+language+} dictionary.
 
 The following example configures a ``MongoClient`` object to use ``RawBSONDocument`` objects
-to model the collection, then retrieves the sample document from the preceding examples:
+to model the collection, then retrieves the sample document from the preceding examples.
+Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding
+code.
 
 .. tabs::
    

--- a/source/data-formats/custom-types.txt
+++ b/source/data-formats/custom-types.txt
@@ -29,26 +29,54 @@ the driver doesn't understand. For example, the
 BSON library's ``Decimal128`` type is distinct
 from Python's built-in ``Decimal`` type. Attempting
 to save an instance of ``Decimal`` with {+driver-short+} results in an
-``InvalidDocument`` exception, as shown in the following code example:
+``InvalidDocument`` exception, as shown in the following code example. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
 
-   .. input::
-      :language: python
+   .. tab:: Synchronous
+      :tabid: sync
 
-      from decimal import Decimal
+      .. io-code-block::
+         :copyable: true
 
-      num = Decimal("45.321")
-      db["coll"].insert_one({"num": num})
+         .. input::
+            :language: python
 
-   .. output::
-      :language: shell
+            from decimal import Decimal
 
-      Traceback (most recent call last):
-      ...
-      bson.errors.InvalidDocument: cannot encode object: Decimal('45.321'), of
-      type: <class 'decimal.Decimal'>
+            num = Decimal("45.321")
+            db["coll"].insert_one({"num": num})
+
+         .. output::
+            :language: shell
+
+            Traceback (most recent call last):
+            ...
+            bson.errors.InvalidDocument: cannot encode object: Decimal('45.321'), of
+            type: <class 'decimal.Decimal'>
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            from decimal import Decimal
+
+            num = Decimal("45.321")
+            await db["coll"].insert_one({"num": num})
+
+         .. output::
+            :language: shell
+
+            Traceback (most recent call last):
+            ...
+            bson.errors.InvalidDocument: cannot encode object: Decimal('45.321'), of
+            type: <class 'decimal.Decimal'>
 
 The following sections show how to define a custom type for this ``Decimal`` type.
 
@@ -154,46 +182,97 @@ object as a keyword argument. Pass your ``CodecOptions`` object to the
   codec_options = CodecOptions(type_registry=type_registry)
   collection = db.get_collection("test", codec_options=codec_options)
 
-You can then encode and decode instances of the ``Decimal`` class:
+You can then encode and decode instances of the ``Decimal`` class. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
+      .. io-code-block::
+         :copyable: true
 
-      import pprint
-  
-      collection.insert_one({"num": Decimal("45.321")})
-      my_doc = collection.find_one()
-      pprint.pprint(my_doc)
+         .. input::
+            :language: python
 
-   .. output::
-      :language: shell
-  
-      {'_id': ObjectId('...'), 'num': Decimal('45.321')}
+            import pprint
+      
+            collection.insert_one({"num": Decimal("45.321")})
+            my_doc = collection.find_one()
+            pprint.pprint(my_doc)
+
+         .. output::
+            :language: shell
+      
+            {'_id': ObjectId('...'), 'num': Decimal('45.321')}
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            import pprint
+      
+            await collection.insert_one({"num": Decimal("45.321")})
+            my_doc = await collection.find_one()
+            pprint.pprint(my_doc)
+
+         .. output::
+            :language: shell
+      
+            {'_id': ObjectId('...'), 'num': Decimal('45.321')}
 
 To see how MongoDB stores an instance of the custom type,
 create a new collection object without the customized codec options, then use it
 to retrieve the document containing the custom type. The following example shows
 that {+driver-short+} stores an instance of the ``Decimal`` class as a ``Decimal128``
-value:
+value. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
+corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
 
-   .. input::
-      :language: python
+   .. tab:: Synchronous
+      :tabid: sync
 
-      import pprint
+      .. io-code-block::
+         :copyable: true
 
-      new_collection = db.get_collection("test")
-      pprint.pprint(new_collection.find_one())
+         .. input::
+            :language: python
 
-   .. output::
-      :language: shell
+            import pprint
 
-      {'_id': ObjectId('...'), 'num': Decimal128('45.321')}
+            new_collection = db.get_collection("test")
+            pprint.pprint(new_collection.find_one())
+
+         .. output::
+            :language: shell
+
+            {'_id': ObjectId('...'), 'num': Decimal128('45.321')}
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            import pprint
+
+            new_collection = db.get_collection("test")
+            pprint.pprint(await new_collection.find_one())
+
+         .. output::
+            :language: shell
+
+            {'_id': ObjectId('...'), 'num': Decimal128('45.321')}
 
 Encode a Subtype
 ----------------
@@ -209,23 +288,48 @@ return its value as an integer:
            return int(self)
 
 If you try to save an instance of the ``DecimalInt`` class without first registering a type
-codec for it, {+driver-short+} raises an error:
+codec for it, {+driver-short+} raises an error. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
 
-   .. input::
-      :language: python
+   .. tab:: Synchronous
+      :tabid: sync
 
-      collection.insert_one({"num": DecimalInt("45.321")})
+      .. io-code-block::
+         :copyable: true
 
-   .. output::
-      :language: shell
+         .. input::
+            :language: python
 
-      Traceback (most recent call last):
-      ...
-      bson.errors.InvalidDocument: cannot encode object: Decimal('45.321'),
-      of type: <class 'decimal.Decimal'>
+            collection.insert_one({"num": DecimalInt("45.321")})
+
+         .. output::
+            :language: shell
+
+            Traceback (most recent call last):
+            ...
+            bson.errors.InvalidDocument: cannot encode object: Decimal('45.321'),
+            of type: <class 'decimal.Decimal'>
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            await collection.insert_one({"num": DecimalInt("45.321")})
+
+         .. output::
+            :language: shell
+
+            Traceback (most recent call last):
+            ...
+            bson.errors.InvalidDocument: cannot encode object: Decimal('45.321'),
+            of type: <class 'decimal.Decimal'>
 
 To encode an instance of the ``DecimalInt`` class, you must define a type codec for
 the class. This type codec must inherit from the parent class's codec, ``DecimalCodec``,
@@ -240,31 +344,64 @@ as shown in the following example:
            return DecimalInt
 
 You can then add the sublcass's type codec to the type registry and encode instances
-of the custom type:
+of the custom type. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
 
-   .. input::
-      :language: python
+   .. tab:: Synchronous
+      :tabid: sync
 
-      import pprint
-      from bson.codec_options import CodecOptions
+      .. io-code-block::
+         :copyable: true
 
-      decimal_int_codec = DecimalIntCodec()
-      type_registry = TypeRegistry([decimal_codec, decimal_int_codec])
-      codec_options = CodecOptions(type_registry=type_registry)
+         .. input::
+            :language: python
 
-      collection = db.get_collection("test", codec_options=codec_options)
-      collection.insert_one({"num": DecimalInt("45.321")})
-  
-      my_doc = collection.find_one()
-      pprint.pprint(my_doc)
+            import pprint
+            from bson.codec_options import CodecOptions
 
-   .. output::
-      :language: shell
+            decimal_int_codec = DecimalIntCodec()
+            type_registry = TypeRegistry([decimal_codec, decimal_int_codec])
+            codec_options = CodecOptions(type_registry=type_registry)
 
-      {'_id': ObjectId('...'), 'num': Decimal('45.321')}
+            collection = db.get_collection("test", codec_options=codec_options)
+            collection.insert_one({"num": DecimalInt("45.321")})
+      
+            my_doc = collection.find_one()
+            pprint.pprint(my_doc)
+
+         .. output::
+            :language: shell
+
+            {'_id': ObjectId('...'), 'num': Decimal('45.321')}
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            import pprint
+            from bson.codec_options import CodecOptions
+
+            decimal_int_codec = DecimalIntCodec()
+            type_registry = TypeRegistry([decimal_codec, decimal_int_codec])
+            codec_options = CodecOptions(type_registry=type_registry)
+
+            collection = db.get_collection("test", codec_options=codec_options)
+            await collection.insert_one({"num": DecimalInt("45.321")})
+      
+            my_doc = collection.find_one()
+            pprint.pprint(my_doc)
+
+         .. output::
+            :language: shell
+
+            {'_id': ObjectId('...'), 'num': Decimal('45.321')}
 
 .. note::
   
@@ -306,8 +443,8 @@ The following code example shows this process:
    collection = db.get_collection("test", codec_options=codec_options)
 
 You can then use this reference to a collection to store instances of the ``Decimal``
-class. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
-corresponding code.
+class. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 .. tabs::
    
@@ -409,8 +546,8 @@ back into Python objects:
           return value
 
 You can then add the ``PickledBinaryDecoder`` to the codec options for a collection
-and use it to encode and decode your custom types. Select the :guilabel:`Synchronous` or
-:guilabel:`Asynchronous` tab to see the corresponding code.
+and use it to encode and decode your custom types. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 .. tabs::
    

--- a/source/data-formats/custom-types.txt
+++ b/source/data-formats/custom-types.txt
@@ -30,7 +30,7 @@ BSON library's ``Decimal128`` type is distinct
 from Python's built-in ``Decimal`` type. Attempting
 to save an instance of ``Decimal`` with {+driver-short+} results in an
 ``InvalidDocument`` exception, as shown in the following code example. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
 
@@ -183,7 +183,7 @@ object as a keyword argument. Pass your ``CodecOptions`` object to the
   collection = db.get_collection("test", codec_options=codec_options)
 
 You can then encode and decode instances of the ``Decimal`` class. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -232,7 +232,7 @@ create a new collection object without the customized codec options, then use it
 to retrieve the document containing the custom type. The following example shows
 that {+driver-short+} stores an instance of the ``Decimal`` class as a ``Decimal128``
 value. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
-corresponding code.
+corresponding code:
 
 .. tabs::
 
@@ -289,7 +289,7 @@ return its value as an integer:
 
 If you try to save an instance of the ``DecimalInt`` class without first registering a type
 codec for it, {+driver-short+} raises an error. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
 
@@ -345,7 +345,7 @@ as shown in the following example:
 
 You can then add the sublcass's type codec to the type registry and encode instances
 of the custom type. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
 
@@ -443,8 +443,8 @@ The following code example shows this process:
    collection = db.get_collection("test", codec_options=codec_options)
 
 You can then use this reference to a collection to store instances of the ``Decimal``
-class. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+class. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
+corresponding code:
 
 .. tabs::
    
@@ -547,7 +547,7 @@ back into Python objects:
 
 You can then add the ``PickledBinaryDecoder`` to the codec options for a collection
 and use it to encode and decode your custom types. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    

--- a/source/data-formats/custom-types.txt
+++ b/source/data-formats/custom-types.txt
@@ -306,24 +306,50 @@ The following code example shows this process:
    collection = db.get_collection("test", codec_options=codec_options)
 
 You can then use this reference to a collection to store instances of the ``Decimal``
-class:
+class. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
+corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
+      .. io-code-block::
+         :copyable: true
 
-      import pprint
+         .. input::
+            :language: python
 
-      collection.insert_one({"num": Decimal("45.321")})
-      my_doc = collection.find_one()
-      pprint.pprint(my_doc)
+            import pprint
 
-   .. output::
-      :language: shell
+            collection.insert_one({"num": Decimal("45.321")})
+            my_doc = collection.find_one()
+            pprint.pprint(my_doc)
 
-      {'_id': ObjectId('...'), 'num': Decimal128('45.321')}
+         .. output::
+            :language: shell
+
+            {'_id': ObjectId('...'), 'num': Decimal128('45.321')}
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            import pprint
+
+            await collection.insert_one({"num": Decimal("45.321")})
+            my_doc = await collection.find_one()
+            pprint.pprint(my_doc)
+
+         .. output::
+            :language: shell
+
+            {'_id': ObjectId('...'), 'num': Decimal128('45.321')}
 
 .. note::
 
@@ -383,36 +409,74 @@ back into Python objects:
           return value
 
 You can then add the ``PickledBinaryDecoder`` to the codec options for a collection
-and use it to encode and decode your custom types:
+and use it to encode and decode your custom types. Select the :guilabel:`Synchronous` or
+:guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
+      .. io-code-block::
+         :copyable: true
 
-      from bson.codec_options import CodecOptions,TypeRegistry
+         .. input::
+            :language: python
 
-      codec_options = CodecOptions(
-          type_registry=TypeRegistry(
-              [PickledBinaryDecoder()], fallback_encoder=fallback_pickle_encoder
-        )
-      )
+            from bson.codec_options import CodecOptions,TypeRegistry
 
-      collection = db.get_collection("test", codec_options=codec_options)
-      collection.insert_one(
-          {"_id": 1, "str": MyStringType("hello world"), "num": MyNumberType(2)}
-      )
-      my_doc = collection.find_one()
+            codec_options = CodecOptions(
+               type_registry=TypeRegistry(
+                  [PickledBinaryDecoder()], fallback_encoder=fallback_pickle_encoder
+            )
+            )
 
-      print(isinstance(my_doc["str"], MyStringType))
-      print(isinstance(my_doc["num"], MyNumberType))
+            collection = db.get_collection("test", codec_options=codec_options)
+            collection.insert_one(
+               {"_id": 1, "str": MyStringType("hello world"), "num": MyNumberType(2)}
+            )
+            my_doc = collection.find_one()
 
-   .. output::
-      :language: shell
+            print(isinstance(my_doc["str"], MyStringType))
+            print(isinstance(my_doc["num"], MyNumberType))
 
-      True
-      True
+         .. output::
+            :language: shell
+
+            True
+            True
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            from bson.codec_options import CodecOptions,TypeRegistry
+
+            codec_options = CodecOptions(
+               type_registry=TypeRegistry(
+                  [PickledBinaryDecoder()], fallback_encoder=fallback_pickle_encoder
+            )
+            )
+
+            collection = db.get_collection("test", codec_options=codec_options)
+            await collection.insert_one(
+               {"_id": 1, "str": MyStringType("hello world"), "num": MyNumberType(2)}
+            )
+            my_doc = await collection.find_one()
+
+            print(isinstance(my_doc["str"], MyStringType))
+            print(isinstance(my_doc["num"], MyNumberType))
+
+         .. output::
+            :language: shell
+
+            True
+            True
 
 Limitations
 -----------

--- a/source/data-formats/custom-types.txt
+++ b/source/data-formats/custom-types.txt
@@ -395,7 +395,7 @@ of the custom type. Select the
             collection = db.get_collection("test", codec_options=codec_options)
             await collection.insert_one({"num": DecimalInt("45.321")})
       
-            my_doc = collection.find_one()
+            my_doc = await collection.find_one()
             pprint.pprint(my_doc)
 
          .. output::

--- a/source/data-formats/dates-and-times.txt
+++ b/source/data-formats/dates-and-times.txt
@@ -125,7 +125,7 @@ By default, {+driver-short+} retrieves UTC ``datetime`` values with no supplemen
 information. The following code example retrieves the sample document
 and prints the ``datetime`` value. The printed value is identical to
 the one in the sample document. Select the :guilabel:`Synchronous` or
-:guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -184,7 +184,7 @@ Then, pass the ``CodecOptions`` object to the ``get_collection()`` method.
 
 The following code example retrieves the ``datetime`` value from the sample document as
 an aware ``datetime``. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab
-to see the corresponding code.
+to see the corresponding code:
 
 .. tabs::
    
@@ -258,7 +258,7 @@ Then, create a ``CodecOptions`` object and pass the following arguments to the c
 The following code example retrieves the sample document,
 but uses the ``tz_aware`` and ``tzinfo`` arguments to automatically localize
 the ``datetime`` value to the ``"US/Pacific"`` time zone. Select the :guilabel:`Synchronous`
-or :guilabel:`Asynchronous` tab to see the corresponding code.
+or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -343,7 +343,7 @@ The following code example inserts a document containing a ``datetime`` value lo
 to the ``"US/Pacific"`` time zone. {+driver-short+} uses the attached time zone to convert
 the local time to UTC. When the document is retrieved from MongoDB, the ``datetime`` value
 is in UTC. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
-corresponding code.
+corresponding code:
 
 .. tabs::
    
@@ -601,7 +601,7 @@ attempt to decode the value as a ``datetime.datetime``, allowing
 this behavior to instead return ``~bson.datetime_ms.DatetimeMS`` when
 representations are out-of-range, while returning ``~datetime.datetime``
 objects as before. Select the :guilabel:`Synchronous`
-or :guilabel:`Asynchronous` tab to see the corresponding code.
+or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -664,7 +664,7 @@ class.
 Another option that does not involve setting ``datetime_conversion`` is to
 filter out document values outside of the range supported by
 ``~datetime.datetime``. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -687,7 +687,7 @@ filter out document values outside of the range supported by
          cur = await coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
 
 If you don't need the value of ``datetime``, you can filter out just that field. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    

--- a/source/data-formats/dates-and-times.txt
+++ b/source/data-formats/dates-and-times.txt
@@ -164,7 +164,7 @@ the one in the sample document. Select the :guilabel:`Synchronous` or
             from datetime import datetime
 
             collection = database["sample_collection"]
-            find_result = await (collection.find_one())["date"]
+            find_result = (await collection.find_one())["date"]
             print(f"datetime: {find_result}")
             print(f"datetime.tzinfo: {find_result.tzinfo}")
 
@@ -230,7 +230,7 @@ to see the corresponding code:
 
             options = CodecOptions(tz_aware = True)
             collection = database.get_collection("sample_collection", options)
-            find_result = await (collection.find_one())["date"]
+            find_result = (await collection.find_one())["date"]
             
             print(f"datetime: {find_result}")
             print(f"datetime.tzinfo: {find_result.tzinfo}")
@@ -311,7 +311,7 @@ or :guilabel:`Asynchronous` tab to see the corresponding code:
             options = CodecOptions(tz_aware = True, tzinfo = pacific)
             collection = database.get_collection("sample_collection", options)
             
-            find_result = await (collection.find_one())["date"]
+            find_result = (await collection.find_one())["date"]
             print(f"datetime: {find_result}")
             print(f"datetime.tzinfo: {find_result.tzinfo}")
          
@@ -395,7 +395,7 @@ corresponding code:
 
             print(f"datetime before storage: {local_datetime}")
             await collection.insert_one({"date": local_datetime}) 
-            find_result = await (collection.find_one())["date"]
+            find_result = (await collection.find_one())["date"]
             print(f"datetime after storage: {find_result}")
 
          .. output::
@@ -684,7 +684,7 @@ filter out document values outside of the range supported by
 
          from datetime import datetime
          coll = client.test.dates
-         cur = await coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
+         cur = coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
 
 If you don't need the value of ``datetime``, you can filter out just that field. Select the
 :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
@@ -703,7 +703,7 @@ If you don't need the value of ``datetime``, you can filter out just that field.
 
       .. code-block:: python
 
-         cur = await coll.find({}, projection={'dt': False})
+         cur = coll.find({}, projection={'dt': False})
 
 API Documentation
 -----------------

--- a/source/data-formats/dates-and-times.txt
+++ b/source/data-formats/dates-and-times.txt
@@ -124,27 +124,56 @@ Naive UTC datetime
 By default, {+driver-short+} retrieves UTC ``datetime`` values with no supplemental
 information. The following code example retrieves the sample document
 and prints the ``datetime`` value. The printed value is identical to
-the one in the sample document.
+the one in the sample document. Select the :guilabel:`Synchronous` or
+:guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
+      .. io-code-block::
+         :copyable: true
 
-      from datetime import datetime
+         .. input::
+            :language: python
 
-      collection = database["sample_collection"]
-      find_result = collection.find_one()["date"]
-      print(f"datetime: {find_result}")
-      print(f"datetime.tzinfo: {find_result.tzinfo}")
+            from datetime import datetime
 
-   .. output::
-      :language: shell
-      :visible: false
+            collection = database["sample_collection"]
+            find_result = collection.find_one()["date"]
+            print(f"datetime: {find_result}")
+            print(f"datetime.tzinfo: {find_result.tzinfo}")
 
-      datetime: 2002-10-27 14:00:00
-      datetime.tzinfo: None
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime: 2002-10-27 14:00:00
+            datetime.tzinfo: None
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            from datetime import datetime
+
+            collection = database["sample_collection"]
+            find_result = await collection.find_one()["date"]
+            print(f"datetime: {find_result}")
+            print(f"datetime.tzinfo: {find_result.tzinfo}")
+
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime: 2002-10-27 14:00:00
+            datetime.tzinfo: None
 
 Aware UTC datetime
 ~~~~~~~~~~~~~~~~~~
@@ -154,31 +183,65 @@ create a ``CodecOptions`` object and pass ``tz_aware = True`` to the constructor
 Then, pass the ``CodecOptions`` object to the ``get_collection()`` method.
 
 The following code example retrieves the ``datetime`` value from the sample document as
-an aware ``datetime``:
+an aware ``datetime``. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab
+to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
+      .. io-code-block::
+         :copyable: true
 
-      from pymongo import MongoClient 
-      from datetime import datetime
-      from bson.codec_options import CodecOptions
+         .. input::
+            :language: python
 
-      options = CodecOptions(tz_aware = True)
-      collection = database.get_collection("sample_collection", options)
-      find_result = collection.find_one()["date"]
+            from pymongo import MongoClient 
+            from datetime import datetime
+            from bson.codec_options import CodecOptions
+
+            options = CodecOptions(tz_aware = True)
+            collection = database.get_collection("sample_collection", options)
+            find_result = collection.find_one()["date"]
+            
+            print(f"datetime: {find_result}")
+            print(f"datetime.tzinfo: {find_result.tzinfo}")
+
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime: 2002-10-27 14:00:00+00:00
+            datetime.tzinfo: <bson.tz_util.FixedOffset object at 0x104db2b80>
+
+   .. tab:: Asynchronous
+      :tabid: async
       
-      print(f"datetime: {find_result}")
-      print(f"datetime.tzinfo: {find_result.tzinfo}")
+      .. io-code-block::
+         :copyable: true
 
-   .. output::
-      :language: shell
-      :visible: false
+         .. input::
+            :language: python
 
-      datetime: 2002-10-27 14:00:00+00:00
-      datetime.tzinfo: <bson.tz_util.FixedOffset object at 0x104db2b80>
+            from pymongo import MongoClient 
+            from datetime import datetime
+            from bson.codec_options import CodecOptions
+
+            options = CodecOptions(tz_aware = True)
+            collection = database.get_collection("sample_collection", options)
+            find_result = await collection.find_one()["date"]
+            
+            print(f"datetime: {find_result}")
+            print(f"datetime.tzinfo: {find_result.tzinfo}")
+
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime: 2002-10-27 14:00:00+00:00
+            datetime.tzinfo: <bson.tz_util.FixedOffset object at 0x104db2b80>
+
 
 Localized datetime
 ~~~~~~~~~~~~~~~~~~
@@ -194,34 +257,70 @@ Then, create a ``CodecOptions`` object and pass the following arguments to the c
 
 The following code example retrieves the sample document,
 but uses the ``tz_aware`` and ``tzinfo`` arguments to automatically localize
-the ``datetime`` value to the ``"US/Pacific"`` time zone:
+the ``datetime`` value to the ``"US/Pacific"`` time zone. Select the :guilabel:`Synchronous`
+or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-   :copyable: true
-
-   .. input::
-      :language: python
-
-      from pymongo import MongoClient 
-      from datetime import datetime
-      from bson.codec_options import CodecOptions
-      import pytz
-      from pytz import timezone
-
-      pacific = timezone("US/Pacific")
-      options = CodecOptions(tz_aware = True, tzinfo = pacific)
-      collection = database.get_collection("sample_collection", options)
-      
-      find_result = collection.find_one()["date"]
-      print(f"datetime: {find_result}")
-      print(f"datetime.tzinfo: {find_result.tzinfo}")
+.. tabs::
    
-   .. output::
-      :language: shell
-      :visible: false
+   .. tab:: Synchronous
+      :tabid: sync
 
-      datetime: 2002-10-27 06:00:00-08:00
-      datetime.tzinfo: US/Pacific
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            from pymongo import MongoClient 
+            from datetime import datetime
+            from bson.codec_options import CodecOptions
+            import pytz
+            from pytz import timezone
+
+            pacific = timezone("US/Pacific")
+            options = CodecOptions(tz_aware = True, tzinfo = pacific)
+            collection = database.get_collection("sample_collection", options)
+            
+            find_result = collection.find_one()["date"]
+            print(f"datetime: {find_result}")
+            print(f"datetime.tzinfo: {find_result.tzinfo}")
+         
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime: 2002-10-27 06:00:00-08:00
+            datetime.tzinfo: US/Pacific
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            from pymongo import MongoClient 
+            from datetime import datetime
+            from bson.codec_options import CodecOptions
+            import pytz
+            from pytz import timezone
+
+            pacific = timezone("US/Pacific")
+            options = CodecOptions(tz_aware = True, tzinfo = pacific)
+            collection = database.get_collection("sample_collection", options)
+            
+            find_result = await collection.find_one()["date"]
+            print(f"datetime: {find_result}")
+            print(f"datetime.tzinfo: {find_result.tzinfo}")
+         
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime: 2002-10-27 06:00:00-08:00
+            datetime.tzinfo: US/Pacific
 
 .. tip::
    
@@ -243,33 +342,69 @@ whether the ``datetime`` value is naive or aware:
 The following code example inserts a document containing a ``datetime`` value localized
 to the ``"US/Pacific"`` time zone. {+driver-short+} uses the attached time zone to convert
 the local time to UTC. When the document is retrieved from MongoDB, the ``datetime`` value
-is in UTC.
+is in UTC. Select the :guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the
+corresponding code.
 
-.. io-code-block::
-   :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   .. input::
-      :language: python
+      .. io-code-block::
+         :copyable: true
 
-      from pymongo import MongoClient 
-      from datetime import datetime
-      from pytz import timezone
-      
-      utc_datetime = datetime(2002, 10, 27, 6, 0, 0)
-      pacific = timezone("US/Pacific")
-      local_datetime = pacific.localize(utc_datetime)
+         .. input::
+            :language: python
 
-      print(f"datetime before storage: {local_datetime}")
-      collection.insert_one({"date": local_datetime}) 
-      find_result = collection.find_one()["date"]
-      print(f"datetime after storage: {find_result}")
+            from pymongo import MongoClient 
+            from datetime import datetime
+            from pytz import timezone
+            
+            utc_datetime = datetime(2002, 10, 27, 6, 0, 0)
+            pacific = timezone("US/Pacific")
+            local_datetime = pacific.localize(utc_datetime)
 
-   .. output::
-      :language: shell
-      :visible: false
+            print(f"datetime before storage: {local_datetime}")
+            collection.insert_one({"date": local_datetime}) 
+            find_result = collection.find_one()["date"]
+            print(f"datetime after storage: {find_result}")
 
-      datetime before storage: 2002-10-27 06:00:00-08:00
-      datetime after storage: 2002-10-27 14:00:00
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime before storage: 2002-10-27 06:00:00-08:00
+            datetime after storage: 2002-10-27 14:00:00
+   
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+         :copyable: true
+
+         .. input::
+            :language: python
+
+            from pymongo import MongoClient 
+            from datetime import datetime
+            from pytz import timezone
+            
+            utc_datetime = datetime(2002, 10, 27, 6, 0, 0)
+            pacific = timezone("US/Pacific")
+            local_datetime = pacific.localize(utc_datetime)
+
+            print(f"datetime before storage: {local_datetime}")
+            await collection.insert_one({"date": local_datetime}) 
+            find_result = await collection.find_one()["date"]
+            print(f"datetime after storage: {find_result}")
+
+         .. output::
+            :language: shell
+            :visible: false
+
+            datetime before storage: 2002-10-27 06:00:00-08:00
+            datetime after storage: 2002-10-27 14:00:00
+
 
 .. important:: datetime.now()
    
@@ -465,30 +600,62 @@ attempt to decode the value as a ``datetime.datetime``, allowing
 ``~bson.codec_options.DatetimeConversion.DATETIME_AUTO`` alters
 this behavior to instead return ``~bson.datetime_ms.DatetimeMS`` when
 representations are out-of-range, while returning ``~datetime.datetime``
-objects as before:
+objects as before. Select the :guilabel:`Synchronous`
+or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. io-code-block::
-
-   .. input::
-      :language: python
-
-      from datetime import datetime
-      from bson.datetime_ms import DatetimeMS
-      from bson.codec_options import DatetimeConversion
-      from pymongo import MongoClient
-
-      client = MongoClient(datetime_conversion=DatetimeConversion.DATETIME_AUTO)
-      client.db.collection.insert_one({"x": datetime(1970, 1, 1)})
-
-      client.db.collection.insert_one({"x": DatetimeMS(2**62)})
-
-      for x in client.db.collection.find():
-         print(x)
+.. tabs::
    
-   .. output::
+   .. tab:: Synchronous
+      :tabid: sync
 
-      {'_id': ObjectId('...'), 'x': datetime.datetime(1970, 1, 1, 0, 0)}
-      {'_id': ObjectId('...'), 'x': DatetimeMS(4611686018427387904)}
+      .. io-code-block::
+
+         .. input::
+            :language: python
+
+            from datetime import datetime
+            from bson.datetime_ms import DatetimeMS
+            from bson.codec_options import DatetimeConversion
+            from pymongo import MongoClient
+
+            client = MongoClient(datetime_conversion=DatetimeConversion.DATETIME_AUTO)
+            client.db.collection.insert_one({"x": datetime(1970, 1, 1)})
+
+            client.db.collection.insert_one({"x": DatetimeMS(2**62)})
+
+            for x in client.db.collection.find():
+               print(x)
+         
+         .. output::
+
+            {'_id': ObjectId('...'), 'x': datetime.datetime(1970, 1, 1, 0, 0)}
+            {'_id': ObjectId('...'), 'x': DatetimeMS(4611686018427387904)}
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+
+         .. input::
+            :language: python
+
+            from datetime import datetime
+            from bson.datetime_ms import DatetimeMS
+            from bson.codec_options import DatetimeConversion
+            from pymongo import MongoClient
+
+            client = AsyncMongoClient(datetime_conversion=DatetimeConversion.DATETIME_AUTO)
+            await client.db.collection.insert_one({"x": datetime(1970, 1, 1)})
+
+            await client.db.collection.insert_one({"x": DatetimeMS(2**62)})
+
+            async for x in client.db.collection.find():
+               print(x)
+         
+         .. output::
+
+            {'_id': ObjectId('...'), 'x': datetime.datetime(1970, 1, 1, 0, 0)}
+            {'_id': ObjectId('...'), 'x': DatetimeMS(4611686018427387904)}
 
 For other options, see the API documentation for the
 `DatetimeConversion <{+api-root+}bson/codec_options.html#bson.codec_options.DatetimeConversion>`__
@@ -498,17 +665,43 @@ Another option that does not involve setting ``datetime_conversion`` is to
 filter out document values outside of the range supported by
 ``~datetime.datetime``:
 
-.. code-block:: python
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   from datetime import datetime
-   coll = client.test.dates
-   cur = coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
+      .. code-block:: python
+
+         from datetime import datetime
+         coll = client.test.dates
+         cur = coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. code-block:: python
+
+         from datetime import datetime
+         coll = client.test.dates
+         cur = await coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
 
 If you don't need the value of ``datetime``, you can filter out just that field: 
 
-.. code-block:: python
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-   cur = coll.find({}, projection={'dt': False})
+      .. code-block:: python
+
+         cur = coll.find({}, projection={'dt': False})
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. code-block:: python
+
+         cur = await coll.find({}, projection={'dt': False})
 
 API Documentation
 -----------------

--- a/source/data-formats/dates-and-times.txt
+++ b/source/data-formats/dates-and-times.txt
@@ -164,7 +164,7 @@ the one in the sample document. Select the :guilabel:`Synchronous` or
             from datetime import datetime
 
             collection = database["sample_collection"]
-            find_result = await collection.find_one()["date"]
+            find_result = await (collection.find_one())["date"]
             print(f"datetime: {find_result}")
             print(f"datetime.tzinfo: {find_result.tzinfo}")
 
@@ -230,7 +230,7 @@ to see the corresponding code.
 
             options = CodecOptions(tz_aware = True)
             collection = database.get_collection("sample_collection", options)
-            find_result = await collection.find_one()["date"]
+            find_result = await (collection.find_one())["date"]
             
             print(f"datetime: {find_result}")
             print(f"datetime.tzinfo: {find_result.tzinfo}")
@@ -311,7 +311,7 @@ or :guilabel:`Asynchronous` tab to see the corresponding code.
             options = CodecOptions(tz_aware = True, tzinfo = pacific)
             collection = database.get_collection("sample_collection", options)
             
-            find_result = await collection.find_one()["date"]
+            find_result = await (collection.find_one())["date"]
             print(f"datetime: {find_result}")
             print(f"datetime.tzinfo: {find_result.tzinfo}")
          
@@ -395,7 +395,7 @@ corresponding code.
 
             print(f"datetime before storage: {local_datetime}")
             await collection.insert_one({"date": local_datetime}) 
-            find_result = await collection.find_one()["date"]
+            find_result = await (collection.find_one())["date"]
             print(f"datetime after storage: {find_result}")
 
          .. output::
@@ -663,7 +663,8 @@ class.
 
 Another option that does not involve setting ``datetime_conversion`` is to
 filter out document values outside of the range supported by
-``~datetime.datetime``:
+``~datetime.datetime``. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 .. tabs::
    
@@ -685,7 +686,8 @@ filter out document values outside of the range supported by
          coll = client.test.dates
          cur = await coll.find({'dt': {'$gte': datetime.min, '$lte': datetime.max}})
 
-If you don't need the value of ``datetime``, you can filter out just that field: 
+If you don't need the value of ``datetime``, you can filter out just that field. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 .. tabs::
    

--- a/source/data-formats/time-series.txt
+++ b/source/data-formats/time-series.txt
@@ -83,47 +83,103 @@ Example
 ~~~~~~~
 
 The following example creates a time series collection named ``october2024`` with the
-``timeField`` option set to ``"timestamp"``:
+``timeField`` option set to ``"timestamp"``. Select the :guilabel:`Synchronous`
+or :guilabel:`Asynchronous` tab to see the corresponding code.
 
-.. code-block:: python
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-    database = client.get_database("weather")
+      .. code-block:: python
 
-    time_series_options = {
-        "timeField": "timestamp"
-    }
+          database = client.get_database("weather")
 
-    database.create_collection("october2024", timeseries=time_series_options)
+          time_series_options = {
+              "timeField": "timestamp"
+          }
+
+          database.create_collection("october2024", timeseries=time_series_options)
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. code-block:: python
+
+          database = client.get_database("weather")
+
+          time_series_options = {
+              "timeField": "timestamp"
+          }
+
+          await database.create_collection("october2024", timeseries=time_series_options)
+
 
 To check if you successfully created the collection, you can get a list of all
 collections in your database and filter by collection name:
 
-.. io-code-block::
-    :copyable: true
+.. tabs::
+   
+   .. tab:: Synchronous
+      :tabid: sync
 
-    .. input::
-        :language: python
-        
-        print(list(database.list_collections(filter={'name': 'october2024'})))
+      .. io-code-block::
+          :copyable: true
 
-    .. output::
-        :language: json
-        :visible: false
+          .. input::
+              :language: python
+              
+              print(list(database.list_collections(filter={'name': 'october2024'})))
 
-        {
-            "name": "october2024", 
-            "type": "timeseries", 
-            "options": {
-                "timeseries":   {
-                    "timeField": "timestamp",
-                    "granularity": "seconds", 
-                    "bucketMaxSpanSeconds": 3600
-                }
-            }, 
-            "info": {
-                "readOnly": False
-            }
-        }
+          .. output::
+              :language: json
+              :visible: false
+
+              {
+                  "name": "october2024", 
+                  "type": "timeseries", 
+                  "options": {
+                      "timeseries":   {
+                          "timeField": "timestamp",
+                          "granularity": "seconds", 
+                          "bucketMaxSpanSeconds": 3600
+                      }
+                  }, 
+                  "info": {
+                      "readOnly": False
+                  }
+              }
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. io-code-block::
+          :copyable: true
+
+          .. input::
+              :language: python
+              
+              collections = await database.list_collections(filter={'name': 'october2024'})
+              print(await collections.to_list())
+
+          .. output::
+              :language: json
+              :visible: false
+
+              {
+                  "name": "october2024", 
+                  "type": "timeseries", 
+                  "options": {
+                      "timeseries":   {
+                          "timeField": "timestamp",
+                          "granularity": "seconds", 
+                          "bucketMaxSpanSeconds": 3600
+                      }
+                  }, 
+                  "info": {
+                      "readOnly": False
+                  }
+              }
 
 .. _pymongo-time-series-write:
 
@@ -147,18 +203,39 @@ document contains the following fields:
 - ``location``, which stores location metadata
 - ``timestamp``, which stores the measurement timestamp
 
-.. code-block:: python
+.. tabs::
 
-    from datetime import datetime
+   .. tab:: Synchronous
+      :tabid: sync
 
-    collection = database["october2024"]
+      .. code-block:: python
 
-    document_list = [
-        { "temperature": 77, "location": "New York City", "timestamp": datetime(2024, 10, 22, 6, 0, 0) },
-        { "temperature": 74, "location": "New York City", "timestamp": datetime(2024, 10, 23, 6, 0, 0) }
-    ]
+          from datetime import datetime
 
-    collection.insert_many(document_list)
+          collection = database["october2024"]
+
+          document_list = [
+              { "temperature": 77, "location": "New York City", "timestamp": datetime(2024, 10, 22, 6, 0, 0) },
+              { "temperature": 74, "location": "New York City", "timestamp": datetime(2024, 10, 23, 6, 0, 0) }
+          ]
+
+          collection.insert_many(document_list)
+
+   .. tab:: Asynchronous
+      :tabid: async
+
+      .. code-block:: python
+
+          from datetime import datetime
+
+          collection = database["october2024"]
+
+          document_list = [
+              { "temperature": 77, "location": "New York City", "timestamp": datetime(2024, 10, 22, 6, 0, 0) },
+              { "temperature": 74, "location": "New York City", "timestamp": datetime(2024, 10, 23, 6, 0, 0) }
+          ]
+
+          await collection.insert_many(document_list)
 
 .. tip:: Formatting Dates and Times
 

--- a/source/data-formats/time-series.txt
+++ b/source/data-formats/time-series.txt
@@ -116,7 +116,8 @@ or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 
 To check if you successfully created the collection, you can get a list of all
-collections in your database and filter by collection name:
+collections in your database and filter by collection name. Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 .. tabs::
    
@@ -202,6 +203,9 @@ document contains the following fields:
 - ``temperature``, which stores temperature measurements in degrees Fahrenheit
 - ``location``, which stores location metadata
 - ``timestamp``, which stores the measurement timestamp
+
+Select the
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 .. tabs::
 

--- a/source/data-formats/time-series.txt
+++ b/source/data-formats/time-series.txt
@@ -84,7 +84,7 @@ Example
 
 The following example creates a time series collection named ``october2024`` with the
 ``timeField`` option set to ``"timestamp"``. Select the :guilabel:`Synchronous`
-or :guilabel:`Asynchronous` tab to see the corresponding code.
+or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -117,7 +117,7 @@ or :guilabel:`Asynchronous` tab to see the corresponding code.
 
 To check if you successfully created the collection, you can get a list of all
 collections in your database and filter by collection name. Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
    
@@ -205,7 +205,7 @@ document contains the following fields:
 - ``timestamp``, which stores the measurement timestamp
 
 Select the
-:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code.
+:guilabel:`Synchronous` or :guilabel:`Asynchronous` tab to see the corresponding code:
 
 .. tabs::
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-node/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-48166>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-213--docs-pymongo.netlify.app/data-formats/bson>data-formats/bson</a></li><li><a href=https://deploy-preview-213--docs-pymongo.netlify.app/data-formats/custom-types>data-formats/custom-types</a></li><li><a href=https://deploy-preview-213--docs-pymongo.netlify.app/data-formats/dates-and-times>data-formats/dates-and-times</a></li><li><a href=https://deploy-preview-213--docs-pymongo.netlify.app/data-formats/time-series>data-formats/time-series</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
